### PR TITLE
Fixing symbolic "cmd" path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,8 +23,8 @@ all: install
 
 install:
 	$(install_cwd)
-	(cd cmd/go-python && $(install_cwd))
+	(cd ./cmd/go-python && $(install_cwd))
 
 build:
 	$(build_cwd)
-	(cd cmd/go-python && $(build_cwd))
+	(cd ./cmd/go-python && $(build_cwd))


### PR DESCRIPTION
On ZSH the following error has been raised when not preceding "cmd" folder with "./":

> /bin/sh: line 0: cd: cmd/go-python: No such file or directory
> make: **\* [install] Error 1
