### PR TITLE
Allow access to python bytearrays as []byte

### DIFF
--- a/sequence.go
+++ b/sequence.go
@@ -89,6 +89,19 @@ func PyByteArray_AsString(self *PyObject) string {
 	return C.GoString(c_str)
 }
 
+// Return the contents of bytearray as []bytes
+func PyByteArray_AsBytes(self *PyObject) []byte {
+	length := C._gopy_PyByteArray_GET_SIZE(topy(self))
+	c_str := C.PyByteArray_AsString(topy(self))
+	return C.GoBytes(unsafe.Pointer(c_str),C.int(length))
+}
+
+// Return the contents of bytearray as []bytes, size length
+func PyByteArray_AsBytesN(self *PyObject, length int) []byte {
+	c_str := C.PyByteArray_AsString(topy(self))
+	return C.GoBytes(unsafe.Pointer(c_str),C.int(length))
+}
+
 // int PyByteArray_Resize(PyObject *bytearray, Py_ssize_t len)
 // Resize the internal buffer of bytearray to len.
 func PyByteArray_Resize(self *PyObject, sz int) error {

--- a/sequence.go
+++ b/sequence.go
@@ -89,15 +89,19 @@ func PyByteArray_AsString(self *PyObject) string {
 	return C.GoString(c_str)
 }
 
-// Return the contents of bytearray as []bytes
+// PyByteArray_AsBytes returns the contents of bytearray as []bytes
 func PyByteArray_AsBytes(self *PyObject) []byte {
 	length := C._gopy_PyByteArray_GET_SIZE(topy(self))
 	c_str := C.PyByteArray_AsString(topy(self))
 	return C.GoBytes(unsafe.Pointer(c_str),C.int(length))
 }
 
-// Return the contents of bytearray as []bytes, size length
-func PyByteArray_AsBytesN(self *PyObject, length int) []byte {
+// PyByteArray_AsBytesN returns the contents of bytearray as []bytes, size length
+func PyByteArray_AsBytesN(self *PyObject, length uint64) []byte {
+	blength := uint64(C._gopy_PyByteArray_GET_SIZE(topy(self)))
+	if blength < length {
+		panic("bytearray length out of range")
+	}
 	c_str := C.PyByteArray_AsString(topy(self))
 	return C.GoBytes(unsafe.Pointer(c_str),C.int(length))
 }

--- a/sequence.go
+++ b/sequence.go
@@ -97,9 +97,9 @@ func PyByteArray_AsBytes(self *PyObject) []byte {
 }
 
 // PyByteArray_AsBytesN returns the contents of bytearray as []bytes, size length
-func PyByteArray_AsBytesN(self *PyObject, length uint64) []byte {
-	blength := uint64(C._gopy_PyByteArray_GET_SIZE(topy(self)))
-	if blength < length {
+func PyByteArray_AsBytesN(self *PyObject, length int) []byte {
+	blength := int(C._gopy_PyByteArray_GET_SIZE(topy(self)))
+	if (blength < length) || (length < 0) {
 		panic("bytearray length out of range")
 	}
 	c_str := C.PyByteArray_AsString(topy(self))


### PR DESCRIPTION
With the existing functions I could not find a way to handle python bytearrays that contain zeros - PyByteArray_AsString always cuts the string off at the first zero byte (I guess C.GoString is responsible). Hence I've added the two functions to create []bytes from bytearrays. I'm not sure if that creates a memory leak though.