### PR TITLE
Fix PyDict_Next, C function actually returns bool

### DIFF
--- a/dict.go
+++ b/dict.go
@@ -4,7 +4,6 @@ package python
 import "C"
 
 import (
-	"errors"
 	"unsafe"
 )
 
@@ -160,9 +159,9 @@ func PyDict_Size(self *PyObject) int {
 //     Py_DECREF(o);
 // }
 // Changed in version 2.5: This function used an int * type for ppos. This might require changes in your code for properly supporting 64-bit systems.
-func PyDict_Next(self *PyObject, pos *int, key, value **PyObject) error {
+func PyDict_Next(self *PyObject, pos *int, key, value **PyObject) bool {
 	if pos == nil {
-		return errors.New("invalid position")
+		return false
 	}
 
 	c_pos := C.Py_ssize_t(*pos)
@@ -175,7 +174,7 @@ func PyDict_Next(self *PyObject, pos *int, key, value **PyObject) error {
 	*key = togo(c_key)
 	*value = togo(c_val)
 
-	return int2err(err)
+	return int2bool(err)
 }
 
 // int PyDict_Merge(PyObject *a, PyObject *b, int override)

--- a/object.go
+++ b/object.go
@@ -83,7 +83,7 @@ func int2err(i C.int) error {
 		return nil
 	}
 	//FIXME: also handle python exceptions ?
-	return &gopy_err{fmt.Sprintf("error in C-Python (rc=%i)", int(i))}
+	return &gopy_err{fmt.Sprintf("error in C-Python (rc=%d)", int(i))}
 }
 
 func file2go(f *C.FILE) *os.File {


### PR DESCRIPTION
When iterating dictionaries, the return value from `PyDict_Next` is converted to an error, so even when the functions returns `1` meaning "you can keep iterating", `go-python` assumes it's an exit code != 0.
According to [Python docs](https://docs.python.org/2.7/c-api/dict.html#c.PyDict_Next) the integer return value should be treated as a bool (1 meaning `True`).