### PR TITLE
object: always return the same value for Py_None, Py_True, and Py_False

### DIFF
--- a/none.go
+++ b/none.go
@@ -6,6 +6,6 @@ import "C"
 // The Python None object, denoting lack of value. This object has no methods.
 // It needs to be treated just like any other object with respect to reference
 // counts.
-var Py_None = togo(C._gopy_pynone())
+var Py_None = &PyObject{ptr: C._gopy_pynone()}
 
 // EOF

--- a/numeric.go
+++ b/numeric.go
@@ -332,13 +332,13 @@ func PyBool_Check(self *PyObject) bool {
 // The Python False object. This object has no methods.
 // It needs to be treated just like any other object with respect to
 // reference counts.
-var Py_False = togo(C._gopy_pyfalse())
+var Py_False = &PyObject{ptr: C._gopy_pyfalse()}
 
 // PyObject* Py_True
 // The Python True object. This object has no methods.
 // It needs to be treated just like any other object with respect to
 // reference counts.
-var Py_True = togo(C._gopy_pytrue())
+var Py_True = &PyObject{ptr: C._gopy_pytrue()}
 
 /*
 Py_RETURN_FALSE

--- a/object.go
+++ b/object.go
@@ -27,10 +27,18 @@ func topy(self *PyObject) *C.PyObject {
 }
 
 func togo(obj *C.PyObject) *PyObject {
-	if obj == nil {
+	switch obj {
+	case nil:
 		return nil
+	case Py_None.ptr:
+		return Py_None
+	case Py_True.ptr:
+		return Py_True
+	case Py_False.ptr:
+		return Py_False
+	default:
+		return &PyObject{ptr: obj}
 	}
-	return &PyObject{ptr: obj}
 }
 
 // PyObject_FromVoidPtr converts a PyObject from an unsafe.Pointer

--- a/python_test.go
+++ b/python_test.go
@@ -140,3 +140,12 @@ func TestIssue61(t *testing.T) {
 `),
 	})
 }
+
+func TestCheckNone(t *testing.T) {
+	t.Parallel()
+	testPkg(t, pkg{
+		path: "tests/none-check",
+		want: []byte(`type=<type 'NoneType'>, str=None, eq_none=true
+`),
+	})
+}

--- a/tests/none-check/get_none.py
+++ b/tests/none-check/get_none.py
@@ -1,0 +1,5 @@
+#!/usr/bin/env python2
+
+def get_none():
+    return None
+

--- a/tests/none-check/main.go
+++ b/tests/none-check/main.go
@@ -1,0 +1,32 @@
+package main
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/sbinet/go-python"
+)
+
+func init() {
+	err := python.Initialize()
+	if err != nil {
+		log.Panic(err)
+	}
+}
+
+func main() {
+	module := python.PyImport_ImportModule("get_none")
+	if module == nil {
+		log.Fatal("could not import 'get_none' module")
+	}
+	get_none := module.GetAttrString("get_none")
+	if get_none == nil {
+		log.Fatal("could not import 'get_none' function")
+	}
+	none := get_none.CallFunction()
+	fmt.Printf("type=%s, str=%s, eq_none=%t\n",
+		python.PyString_AsString(none.Type().Str()),
+		python.PyString_AsString(none.Str()),
+		none == python.Py_None,
+	)
+}


### PR DESCRIPTION
https://docs.python.org/2/c-api/none.html

You're supposed to be able to compare a `python.PyObject` to `python.Py_None` but this doesn't work.

I think we should consider adding a `PyNone_Check` function to compare the underlying pointer.

``` go
// Return true if self is None
func PyNone_Check(self *PyObject) bool {
	return Py_None.ptr == self.ptr
}
```